### PR TITLE
Allow specifying different AWS providers for…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,6 +9,8 @@ locals {
 }
 
 resource "aws_acm_certificate" "this" {
+  provider = aws.acm
+
   count = var.create_certificate ? 1 : 0
 
   domain_name               = var.domain_name
@@ -27,6 +29,8 @@ resource "aws_acm_certificate" "this" {
 }
 
 resource "aws_route53_record" "validation" {
+  provider = aws.dns
+
   count = var.create_certificate && var.validation_method == "DNS" && var.validate_certificate ? length(local.distinct_domain_names) : 0
 
   zone_id = var.zone_id
@@ -44,6 +48,8 @@ resource "aws_route53_record" "validation" {
 }
 
 resource "aws_acm_certificate_validation" "this" {
+  provider = aws.acm
+
   count = var.create_certificate && var.validation_method == "DNS" && var.validate_certificate && var.wait_for_validation ? 1 : 0
 
   certificate_arn = aws_acm_certificate.this[0].arn

--- a/versions.tf
+++ b/versions.tf
@@ -5,3 +5,11 @@ terraform {
     aws = ">= 2.53"
   }
 }
+
+provider "aws" {
+  alias = "dns"
+}
+
+provider "aws" {
+  alias = "acm"
+}


### PR DESCRIPTION
…the DNS operations and the ACM operations, in case they need to be in different accounts.

This PR isn't intended to merge. I believe that this is not backwards compatible with the module API and I don't know what to do about that, but it's what I'm using in the api-catalog repo.